### PR TITLE
Add --input-dir and --output-dir for batch processing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,15 +1,119 @@
 #include <Magick++.h>
 #include <cmath>
+#include <filesystem>
 #include <iostream>
 #include <qrencode.h>
 #include <stdexcept>
 
 #include "config.h"
 #include "extraText.h"
+#include "imageProvider.h"
 #include "logger.h"
 #include "options.h"
 #include "pdfProcessor.h"
 #include "rect.h"
+
+namespace fs = std::filesystem;
+
+static int processPDF(
+    const std::string &inputPath, const std::string &outputPath,
+    const std::unordered_map<std::string,
+                             std::variant<std::string, int, float,
+                                          std::vector<std::string>>> &cliOption,
+    Logger &logger) {
+
+    PDFProcessor pdf_processor(logger);
+    try {
+        pdf_processor.open(inputPath);
+    } catch (const std::runtime_error &e) {
+        std::cerr << e.what() << std::endl;
+        return 4;
+    }
+
+    if (cliOption.contains("rotate")) {
+        pdf_processor.rotate(std::get<int>(cliOption.at("rotate")));
+    }
+
+    int qr_side = 0;
+    if (cliOption.contains("qr-side")) {
+        qr_side = std::get<int>(cliOption.at("qr-side"));
+    }
+    pdf_processor.setPosition(qr_side);
+
+    if (cliOption.contains("qrText")) {
+        logger << "QR Text: " << std::get<std::string>(cliOption.at("qrText"))
+               << "\n";
+        QRcode *qr = QRcode_encodeString(
+            std::get<std::string>(cliOption.at("qrText")).c_str(), 0,
+            QR_ECLEVEL_M, QR_MODE_8, 1);
+
+        if (qr == nullptr) {
+            logger << "QRcode_encodeString failed!\n";
+            std::cerr << "QRcode_encodeString failed!" << std::endl;
+            return 3;
+        }
+
+        logger << "QR version: " << qr->version << "\n";
+        logger << "QR width: " << qr->width << "\n";
+
+        pdf_processor.addImage(new ImageProvider(qr, logger),
+                               std::get<float>(cliOption.at("qr-scale")),
+                               std::get<float>(cliOption.at("qr-top-margin")),
+                               std::get<float>(cliOption.at("qr-side-margin")),
+                               std::get<std::string>(cliOption.at("link")));
+    }
+
+    int img_side = 0;
+    if (cliOption.contains("img-side")) {
+        img_side = std::get<int>(cliOption.at("img-side"));
+    }
+    pdf_processor.setPosition(img_side);
+
+    if (cliOption.contains("imageFile")) {
+        const std::string &imageFile =
+            std::get<std::string>(cliOption.at("imageFile"));
+        ImageProvider *imgProvider;
+        if (imageFile == "-") {
+            imgProvider = new ImageProvider(std::cin, logger);
+        } else {
+            imgProvider = new ImageProvider(imageFile, logger);
+        }
+
+        if (cliOption.contains("img-x")) {
+            Point p(std::get<float>(cliOption.at("img-x")),
+                    std::get<float>(cliOption.at("img-y")));
+            pdf_processor.addImage(
+                imgProvider, std::get<float>(cliOption.at("img-scale")), 0, 0,
+                std::get<std::string>(cliOption.at("img-link-to")), &p);
+        } else {
+            pdf_processor.addImage(
+                imgProvider, std::get<float>(cliOption.at("img-scale")),
+                std::get<float>(cliOption.at("img-top-margin")),
+                std::get<float>(cliOption.at("img-side-margin")),
+                std::get<std::string>(cliOption.at("img-link-to")));
+        }
+    }
+
+    const std::vector<std::string> text_vector =
+        std::get<std::vector<std::string>>(cliOption.at("text"));
+    for (const auto &text : text_vector) {
+        ExtraText parsed_text(text, logger);
+        if (text != "") {
+            pdf_processor.addExtraText(parsed_text.text(), parsed_text.x(),
+                                       parsed_text.y(), parsed_text.font_size(),
+                                       "Helvetica", parsed_text.style());
+        }
+    }
+
+    try {
+        pdf_processor.save(outputPath);
+    } catch (const std::runtime_error &e) {
+        std::cerr << e.what() << std::endl;
+        return 5;
+    }
+
+    return 0;
+}
 
 int main(int argc, char *argv[]) {
 
@@ -33,105 +137,46 @@ int main(int argc, char *argv[]) {
         return 0;
     }
 
-    if (!cliOption.contains("inputPDF")) {
+    if (!cliOption.contains("inputPDF") && !cliOption.contains("inputDir")) {
         return 0;
     }
 
     Magick::InitializeMagick(nullptr);
 
-    PDFProcessor pdf_processor(logger);
-    try {
-        pdf_processor.open(std::get<std::string>(cliOption["inputPDF"]));
-    } catch (const std::runtime_error &e) {
-        std::cerr << e.what() << std::endl;
-        return 4;
-    }
+    int exit_code = 0;
 
-    if (cliOption.contains("rotate")) {
-        pdf_processor.rotate(std::get<int>(cliOption["rotate"]));
-    }
+    if (cliOption.contains("inputDir")) {
+        const std::string &inputDir =
+            std::get<std::string>(cliOption.at("inputDir"));
+        const std::string &outputDir =
+            std::get<std::string>(cliOption.at("outputDir"));
 
-    int qr_side = 0;
-    if (cliOption.contains("qr-side")) {
-        qr_side = std::get<int>(cliOption["qr-side"]);
-    }
-    pdf_processor.setPosition(qr_side);
+        fs::create_directories(outputDir);
 
-    if (cliOption.contains("qrText")) {
-        logger << "QR Text: " << std::get<std::string>(cliOption["qrText"])
-               << "\n";
-        QRcode *qr = QRcode_encodeString(
-            std::get<std::string>(cliOption["qrText"]).c_str(), 0, QR_ECLEVEL_M,
-            QR_MODE_8, 1);
+        for (const auto &entry : fs::directory_iterator(inputDir)) {
+            if (!entry.is_regular_file())
+                continue;
+            const auto &path = entry.path();
+            if (path.extension() != ".pdf")
+                continue;
 
-        if (qr == nullptr) {
-            logger << "QRcode_encodeString failed!\n";
-            std::cerr << "QRcode_encodeString failed!" << std::endl;
-            return 3;
+            std::string outPath = (fs::path(outputDir) / path.filename()).string();
+            logger << "Processing " << path.string() << " -> " << outPath
+                   << "\n";
+
+            int ret = processPDF(path.string(), outPath, cliOption, logger);
+            if (ret != 0) {
+                std::cerr << "Error processing " << path.string() << std::endl;
+                exit_code = ret;
+            }
         }
-
-        logger << "QR version: " << qr->version << "\n";
-        logger << "QR width: " << qr->width << "\n";
-
-        pdf_processor.addImage(new ImageProvider(qr, logger),
-                               std::get<float>(cliOption["qr-scale"]),
-                               std::get<float>(cliOption["qr-top-margin"]),
-                               std::get<float>(cliOption["qr-side-margin"]),
-                               std::get<std::string>(cliOption["link"]));
-    }
-
-    int img_side = 0;
-    if (cliOption.contains("img-side")) {
-        img_side = std::get<int>(cliOption["img-side"]);
-    }
-    pdf_processor.setPosition(img_side);
-
-    if (cliOption.contains("imageFile")) {
-        const std::string &imageFile =
-            std::get<std::string>(cliOption["imageFile"]);
-        ImageProvider *imgProvider;
-        if (imageFile == "-") {
-            imgProvider = new ImageProvider(std::cin, logger);
-        } else {
-            imgProvider = new ImageProvider(imageFile, logger);
-        }
-
-        if (cliOption.contains("img-x")) {
-            Point p(std::get<float>(cliOption["img-x"]),
-                    std::get<float>(cliOption["img-y"]));
-            pdf_processor.addImage(
-                imgProvider, std::get<float>(cliOption["img-scale"]), 0, 0,
-                std::get<std::string>(cliOption["img-link-to"]), &p);
-        } else {
-            pdf_processor.addImage(
-                imgProvider, std::get<float>(cliOption["img-scale"]),
-                std::get<float>(cliOption["img-top-margin"]),
-                std::get<float>(cliOption["img-side-margin"]),
-                std::get<std::string>(cliOption["img-link-to"]));
-        }
-    }
-
-    // Add extra text if requested
-    const std::vector<std::string> text_vector =
-        std::get<std::vector<std::string>>(cliOption["text"]);
-    for (const auto& text : text_vector) {
-        ExtraText parsed_text(text, logger);
-
-        if (text != "") {
-            pdf_processor.addExtraText(parsed_text.text(), parsed_text.x(),
-                                       parsed_text.y(), parsed_text.font_size(),
-                                       "Helvetica", parsed_text.style());
-        }
-    }
-
-    try {
-        pdf_processor.save(std::get<std::string>(cliOption["outputPDF"]));
-    } catch (const std::runtime_error &e) {
-        std::cerr << e.what() << std::endl;
-        return 5;
+    } else {
+        exit_code = processPDF(
+            std::get<std::string>(cliOption.at("inputPDF")),
+            std::get<std::string>(cliOption.at("outputPDF")), cliOption,
+            logger);
     }
 
     Magick::TerminateMagick();
-
-    return 0;
+    return exit_code;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -22,8 +22,10 @@ readCLIOptions(int argc, char *argv[], Logger &logger) {
     generic.add_options()
         ("help,h", "Produce this help message")
         ("version", "Print version string")
-        ("input-file,i", value<std::string>()->required(), "Input file")
-        ("output-file,o", value<std::string>()->required(), "Output file")
+        ("input-file,i", value<std::string>(), "Input file")
+        ("output-file,o", value<std::string>(), "Output file")
+        ("input-dir", value<std::string>(), "Input directory for batch processing")
+        ("output-dir", value<std::string>(), "Output directory for batch processing")
         ("rotate", value<int>()->default_value(0), "Assume page is rotated by 0/90/180/270 degrees")
         ("debug", "Print extra debug messages");
 
@@ -87,6 +89,11 @@ readCLIOptions(int argc, char *argv[], Logger &logger) {
 
         std::cerr << e.what() << std::endl << std::endl;
         throw std::runtime_error("Invalid command-line arguments");
+    }
+
+    if (vm.count("help")) {
+        std::cout << programOptions << std::endl;
+        return cliOption;
     }
 
     if (vm.count("version")) {
@@ -247,9 +254,25 @@ readCLIOptions(int argc, char *argv[], Logger &logger) {
         logger.setEnabled(true);
     }
 
-    if (vm.count("help")) {
-        std::cout << programOptions << std::endl;
-        return cliOption;
+    bool hasInputFile = vm.count("input-file") && vm.count("output-file");
+    bool hasInputDir  = vm.count("input-dir") && vm.count("output-dir");
+
+    if (!hasInputFile && !hasInputDir) {
+        throw std::runtime_error(
+            "Specify either --input-file/--output-file or --input-dir/--output-dir");
+    }
+
+    if (hasInputFile && hasInputDir) {
+        throw std::runtime_error(
+            "Cannot use both --input-file/--output-file and --input-dir/--output-dir");
+    }
+
+    if (vm.count("input-dir")) {
+        cliOption["inputDir"] = vm["input-dir"].as<std::string>();
+    }
+
+    if (vm.count("output-dir")) {
+        cliOption["outputDir"] = vm["output-dir"].as<std::string>();
     }
 
     if (!cliOption.contains("qrText") && !cliOption.contains("imageFile") &&

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -8,9 +8,12 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <string>
+
+namespace fs = std::filesystem;
 
 #include "../src/imageProvider.h"
 #include "../src/pdfProcessor.h"
@@ -505,6 +508,38 @@ TEST_F(CLITest, BadRotateValue) {
     };
     int ret = runBinary(args);
     EXPECT_NE(ret, 0);
+}
+
+TEST_F(CLITest, BatchProcessDirectory) {
+    std::string inDir = std::string(TEST_DATA_DIR) + "/_batch_in";
+    std::string outDir = std::string(TEST_DATA_DIR) + "/_batch_out";
+
+    fs::create_directories(inDir);
+    fs::create_directories(outDir);
+
+    // Copy blank.pdf multiple times into input dir
+    fs::copy(inPath, inDir + "/doc1.pdf", fs::copy_options::overwrite_existing);
+    fs::copy(inPath, inDir + "/doc2.pdf", fs::copy_options::overwrite_existing);
+    fs::copy(inPath, inDir + "/doc3.pdf", fs::copy_options::overwrite_existing);
+
+    std::vector<std::string> args = {
+        "--input-dir", inDir, "--output-dir", outDir, "--qr", "batch-test",
+    };
+    int ret = runBinary(args);
+    EXPECT_EQ(ret, 0);
+
+    EXPECT_TRUE(fs::exists(outDir + "/doc1.pdf"));
+    EXPECT_TRUE(fs::exists(outDir + "/doc2.pdf"));
+    EXPECT_TRUE(fs::exists(outDir + "/doc3.pdf"));
+
+    // Verify each output is a valid PDF
+    for (const auto &f : {"doc1.pdf", "doc2.pdf", "doc3.pdf"}) {
+        QPDF verify;
+        EXPECT_NO_THROW(verify.processFile((outDir + "/" + f).c_str()));
+    }
+
+    fs::remove_all(inDir);
+    fs::remove_all(outDir);
 }
 
 int main(int argc, char **argv) {

--- a/tests/test_options.cpp
+++ b/tests/test_options.cpp
@@ -157,7 +157,75 @@ TEST(OptionsInvalidTest, MissingContentCaughtWithoutArgcCheck) {
     // This validates that the content check (not argc) is the real guard.
     int argc = 5;
     const char *argv[] = {"qpdfImageEmbed", "-i",   "in.pdf", "-o",
-                          "out.pdf",        nullptr};
+                           "out.pdf",        nullptr};
+    EXPECT_THROW(readCLIOptions(argc, const_cast<char **>(argv), logger),
+                 std::runtime_error);
+}
+
+// ============================================================
+// Batch mode option tests
+// ============================================================
+
+TEST(OptionsBatchTest, ValidInputDirWithQR) {
+    int argc = 7;
+    const char *argv[] = {"qpdfImageEmbed", "--input-dir", "/tmp/in",
+                          "--output-dir",   "/tmp/out",    "--qr",
+                          "test",           nullptr};
+    auto opts = readCLIOptions(argc, const_cast<char **>(argv), logger);
+    EXPECT_EQ(std::get<std::string>(opts["inputDir"]), "/tmp/in");
+    EXPECT_EQ(std::get<std::string>(opts["outputDir"]), "/tmp/out");
+    EXPECT_EQ(std::get<std::string>(opts["qrText"]), "test");
+}
+
+TEST(OptionsBatchTest, ValidInputDirWithStamp) {
+    int argc = 7;
+    const char *argv[] = {"qpdfImageEmbed", "--input-dir", "/tmp/in",
+                          "--output-dir",   "/tmp/out",    "--stamp",
+                          "img.png",        nullptr};
+    auto opts = readCLIOptions(argc, const_cast<char **>(argv), logger);
+    EXPECT_EQ(std::get<std::string>(opts["inputDir"]), "/tmp/in");
+    EXPECT_EQ(std::get<std::string>(opts["outputDir"]), "/tmp/out");
+    EXPECT_EQ(std::get<std::string>(opts["imageFile"]), "img.png");
+}
+
+TEST(OptionsInvalidTest, BatchModeMissingOutputDir) {
+    int argc = 5;
+    const char *argv[] = {"qpdfImageEmbed", "--input-dir", "/tmp/in",
+                          "--qr",           "test",        nullptr};
+    EXPECT_THROW(readCLIOptions(argc, const_cast<char **>(argv), logger),
+                 std::runtime_error);
+}
+
+TEST(OptionsInvalidTest, BatchModeMissingInputDir) {
+    int argc = 5;
+    const char *argv[] = {"qpdfImageEmbed", "--output-dir", "/tmp/out",
+                          "--qr",           "test",         nullptr};
+    EXPECT_THROW(readCLIOptions(argc, const_cast<char **>(argv), logger),
+                 std::runtime_error);
+}
+
+TEST(OptionsInvalidTest, BothSingleAndBatchMode) {
+    int argc = 11;
+    const char *argv[] = {"qpdfImageEmbed", "-i",           "in.pdf",
+                          "-o",             "out.pdf",      "--input-dir",
+                          "/tmp/in",        "--output-dir", "/tmp/out",
+                          "--qr",           "test",         nullptr};
+    EXPECT_THROW(readCLIOptions(argc, const_cast<char **>(argv), logger),
+                 std::runtime_error);
+}
+
+TEST(OptionsInvalidTest, BatchModeNoContent) {
+    int argc = 5;
+    const char *argv[] = {"qpdfImageEmbed", "--input-dir", "/tmp/in",
+                          "--output-dir",   "/tmp/out",    nullptr};
+    EXPECT_THROW(readCLIOptions(argc, const_cast<char **>(argv), logger),
+                 std::runtime_error);
+}
+
+TEST(OptionsInvalidTest, NeitherSingleNorBatchMode) {
+    int argc = 7;
+    const char *argv[] = {"qpdfImageEmbed", "--stamp", "img.png", "--qr",
+                          "test",           "--add-text", "hello", nullptr};
     EXPECT_THROW(readCLIOptions(argc, const_cast<char **>(argv), logger),
                  std::runtime_error);
 }


### PR DESCRIPTION
Add --input-dir and --output-dir CLI options to process multiple PDF files at once, applying the same stamps/QR/text to all PDFs in a directory. The --input-file/--output-file and --input-dir/--output-dir pairs are mutually exclusive.

This also refactors the single-file processing logic into a processPDF() function reused by both modes.

Tests:
- 6 new option parsing tests (valid batch, invalid batch, mutual exclusivity)
- 1 new CLI end-to-end integration test (batch process 3 PDFs)