### PR TITLE
feat: add --qr-ecc option for QR error correction level

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,9 +43,13 @@ static int processPDF(
     if (cliOption.contains("qrText")) {
         logger << "QR Text: " << std::get<std::string>(cliOption.at("qrText"))
                << "\n";
+        QRecLevel eccLevel = QR_ECLEVEL_M;
+        if (cliOption.contains("qr-ecc")) {
+            eccLevel = static_cast<QRecLevel>(std::get<int>(cliOption.at("qr-ecc")));
+        }
         QRcode *qr = QRcode_encodeString(
             std::get<std::string>(cliOption.at("qrText")).c_str(), 0,
-            QR_ECLEVEL_M, QR_MODE_8, 1);
+            eccLevel, QR_MODE_8, 1);
 
         if (qr == nullptr) {
             logger << "QRcode_encodeString failed!\n";

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3,6 +3,7 @@
 #include <boost/program_options.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <iostream>
+#include <qrencode.h>
 #include <stdexcept>
 
 using namespace boost::program_options;
@@ -199,13 +200,13 @@ readCLIOptions(int argc, char *argv[], Logger &logger) {
         std::string eccStr = vm["qr-ecc"].as<std::string>();
         int eccLevel;
         if (eccStr == "L" || eccStr == "l") {
-            eccLevel = 0;
+            eccLevel = QR_ECLEVEL_L;
         } else if (eccStr == "M" || eccStr == "m") {
-            eccLevel = 1;
+            eccLevel = QR_ECLEVEL_M;
         } else if (eccStr == "Q" || eccStr == "q") {
-            eccLevel = 2;
+            eccLevel = QR_ECLEVEL_Q;
         } else if (eccStr == "H" || eccStr == "h") {
-            eccLevel = 3;
+            eccLevel = QR_ECLEVEL_H;
         } else {
             throw std::runtime_error(
                 "Invalid QR error correction level. Valid options: L, M, Q, H");
@@ -274,16 +275,16 @@ readCLIOptions(int argc, char *argv[], Logger &logger) {
     }
 
     bool hasInputFile = vm.count("input-file") && vm.count("output-file");
-    bool hasInputDir  = vm.count("input-dir") && vm.count("output-dir");
+    bool hasInputDir = vm.count("input-dir") && vm.count("output-dir");
 
     if (!hasInputFile && !hasInputDir) {
-        throw std::runtime_error(
-            "Specify either --input-file/--output-file or --input-dir/--output-dir");
+        throw std::runtime_error("Specify either --input-file/--output-file or "
+                                 "--input-dir/--output-dir");
     }
 
     if (hasInputFile && hasInputDir) {
-        throw std::runtime_error(
-            "Cannot use both --input-file/--output-file and --input-dir/--output-dir");
+        throw std::runtime_error("Cannot use both --input-file/--output-file "
+                                 "and --input-dir/--output-dir");
     }
 
     if (vm.count("input-dir")) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -50,6 +50,7 @@ readCLIOptions(int argc, char *argv[], Logger &logger) {
     qrOptions.add_options()
         ("qr", value<std::string>(), "Add QR instead of image using the specified text")
         ("link", "QR value is a URL. Add clickable link")
+        ("qr-ecc", value<std::string>()->default_value("M"), "QR error correction level: L (low), M (medium), Q (quartile), H (high)")
         ("qr-side", value<int>()->default_value(0), "Side of the document: 0 center (default), 1 left, 2 right")
         ("qr-scale", value<float>()->default_value(1),"Scale QR by a factor eg. 0.5")
         ("qr-top-margin", value<float>()->default_value(10),"Set a margin for the QR placement from the top of the page")
@@ -192,6 +193,24 @@ readCLIOptions(int argc, char *argv[], Logger &logger) {
             cliOption["link"] = qrText;
         else
             cliOption["link"] = std::string();
+    }
+
+    if (vm.count("qr")) {
+        std::string eccStr = vm["qr-ecc"].as<std::string>();
+        int eccLevel;
+        if (eccStr == "L" || eccStr == "l") {
+            eccLevel = 0;
+        } else if (eccStr == "M" || eccStr == "m") {
+            eccLevel = 1;
+        } else if (eccStr == "Q" || eccStr == "q") {
+            eccLevel = 2;
+        } else if (eccStr == "H" || eccStr == "h") {
+            eccLevel = 3;
+        } else {
+            throw std::runtime_error(
+                "Invalid QR error correction level. Valid options: L, M, Q, H");
+        }
+        cliOption["qr-ecc"] = eccLevel;
     }
 
     float img_scale;

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -71,6 +71,33 @@ TEST(ImageProviderTest, CreateFromQR) {
     delete img;
 }
 
+TEST(ImageProviderTest, CreateFromQR_EccLevelL) {
+    QRcode *qr = QRcode_encodeString("QR ECC L test", 0, QR_ECLEVEL_L,
+                                     QR_MODE_8, 1);
+    ASSERT_NE(qr, nullptr);
+    ImageProvider img(qr, logger);
+    EXPECT_EQ(img.getWidth(), qr->width);
+    QRcode_free(qr);
+}
+
+TEST(ImageProviderTest, CreateFromQR_EccLevelQ) {
+    QRcode *qr = QRcode_encodeString("QR ECC Q test", 0, QR_ECLEVEL_Q,
+                                     QR_MODE_8, 1);
+    ASSERT_NE(qr, nullptr);
+    ImageProvider img(qr, logger);
+    EXPECT_EQ(img.getWidth(), qr->width);
+    QRcode_free(qr);
+}
+
+TEST(ImageProviderTest, CreateFromQR_EccLevelH) {
+    QRcode *qr = QRcode_encodeString("QR ECC H test", 0, QR_ECLEVEL_H,
+                                     QR_MODE_8, 1);
+    ASSERT_NE(qr, nullptr);
+    ImageProvider img(qr, logger);
+    EXPECT_EQ(img.getWidth(), qr->width);
+    QRcode_free(qr);
+}
+
 // ============================================================
 // PDFProcessor tests
 // ============================================================
@@ -482,6 +509,26 @@ TEST_F(CLITest, EmbedQRSuccess) {
     int ret = runBinary(args);
     EXPECT_EQ(ret, 0);
 
+    std::ifstream f(outPath);
+    EXPECT_TRUE(f.good());
+}
+
+TEST_F(CLITest, EmbedQRWithEccL) {
+    std::vector<std::string> args = {
+        "-i", inPath, "-o", outPath, "--qr", "ecc-L-data", "--qr-ecc", "L",
+    };
+    int ret = runBinary(args);
+    EXPECT_EQ(ret, 0);
+    std::ifstream f(outPath);
+    EXPECT_TRUE(f.good());
+}
+
+TEST_F(CLITest, EmbedQRWithEccH) {
+    std::vector<std::string> args = {
+        "-i", inPath, "-o", outPath, "--qr", "ecc-H-data", "--qr-ecc", "H",
+    };
+    int ret = runBinary(args);
+    EXPECT_EQ(ret, 0);
     std::ifstream f(outPath);
     EXPECT_TRUE(f.good());
 }

--- a/tests/test_options.cpp
+++ b/tests/test_options.cpp
@@ -98,13 +98,60 @@ TEST(OptionsInvalidTest, NegativeScale) {
 TEST(OptionsTest, ValidQRInvocation) {
     int argc = 7;
     const char *argv[] = {"qpdfImageEmbed", "-i",   "in.pdf", "-o",
-                          "out.pdf",        "--qr", "test",   nullptr};
+                           "out.pdf",        "--qr", "test",   nullptr};
     auto opts = readCLIOptions(argc, const_cast<char **>(argv), logger);
     EXPECT_EQ(std::get<std::string>(opts["inputPDF"]), "in.pdf");
     EXPECT_EQ(std::get<std::string>(opts["outputPDF"]), "out.pdf");
     EXPECT_EQ(std::get<std::string>(opts["qrText"]), "test");
     EXPECT_FLOAT_EQ(std::get<float>(opts["qr-scale"]), 1.0f);
     EXPECT_FLOAT_EQ(std::get<float>(opts["img-scale"]), 1.0f);
+    // Default ECC level should be M (1)
+    EXPECT_EQ(std::get<int>(opts["qr-ecc"]), 1);
+}
+
+TEST(OptionsTest, QrEccLevelL) {
+    int argc = 9;
+    const char *argv[] = {"qpdfImageEmbed", "-i",       "in.pdf", "-o",
+                           "out.pdf",        "--qr",     "test",   "--qr-ecc",
+                           "L",              nullptr};
+    auto opts = readCLIOptions(argc, const_cast<char **>(argv), logger);
+    EXPECT_EQ(std::get<int>(opts["qr-ecc"]), 0);
+}
+
+TEST(OptionsTest, QrEccLevelM) {
+    int argc = 9;
+    const char *argv[] = {"qpdfImageEmbed", "-i",       "in.pdf", "-o",
+                           "out.pdf",        "--qr",     "test",   "--qr-ecc",
+                           "M",              nullptr};
+    auto opts = readCLIOptions(argc, const_cast<char **>(argv), logger);
+    EXPECT_EQ(std::get<int>(opts["qr-ecc"]), 1);
+}
+
+TEST(OptionsTest, QrEccLevelQ) {
+    int argc = 9;
+    const char *argv[] = {"qpdfImageEmbed", "-i",       "in.pdf", "-o",
+                           "out.pdf",        "--qr",     "test",   "--qr-ecc",
+                           "Q",              nullptr};
+    auto opts = readCLIOptions(argc, const_cast<char **>(argv), logger);
+    EXPECT_EQ(std::get<int>(opts["qr-ecc"]), 2);
+}
+
+TEST(OptionsTest, QrEccLevelH) {
+    int argc = 9;
+    const char *argv[] = {"qpdfImageEmbed", "-i",       "in.pdf", "-o",
+                           "out.pdf",        "--qr",     "test",   "--qr-ecc",
+                           "H",              nullptr};
+    auto opts = readCLIOptions(argc, const_cast<char **>(argv), logger);
+    EXPECT_EQ(std::get<int>(opts["qr-ecc"]), 3);
+}
+
+TEST(OptionsInvalidTest, InvalidQrEccLevel) {
+    int argc = 9;
+    const char *argv[] = {"qpdfImageEmbed", "-i",       "in.pdf", "-o",
+                           "out.pdf",        "--qr",     "test",   "--qr-ecc",
+                           "X",              nullptr};
+    EXPECT_THROW(readCLIOptions(argc, const_cast<char **>(argv), logger),
+                 std::runtime_error);
 }
 
 TEST(OptionsInvalidTest, QrSideOutOfRange) {


### PR DESCRIPTION
Adds `--qr-ecc` CLI option to select QR error correction level (L/M/Q/H, default M).

Previously, `QR_ECLEVEL_M` was hardcoded in `src/main.cpp:48`. Now the level is read from the options map and cast to `QRecLevel`.

### Changes
- **src/options.cpp**: Add `--qr-ecc` option with default "M", validate against L/M/Q/H (case-insensitive), store as int 0-3
- **src/main.cpp**: Read `qr-ecc` from options, use `static_cast<QRecLevel>` instead of hardcoded `QR_ECLEVEL_M`

### Tests (10 new)
- **test_options**: Default ECC is M, valid levels L/M/Q/H, invalid level throws
- **test_integration**: ImageProvider creation with L/Q/H ECC levels; CLI end-to-end with `--qr-ecc L` and `--qr-ecc H`

All 57 tests pass (47 existing + 10 new).