### PR TITLE
feat: add --qr-fg-color and --qr-bg-color for QR color customization

### DIFF
--- a/src/imageProvider.cpp
+++ b/src/imageProvider.cpp
@@ -37,17 +37,22 @@ ImageProvider::ImageProvider(std::istream &stream, Logger &logger)
     processImage();
 }
 
-ImageProvider::ImageProvider(const QRcode *qr, Logger &logger)
+ImageProvider::ImageProvider(const QRcode *qr, Logger &logger,
+                             const Magick::Color &fg, const Magick::Color &bg)
     : m_logger(logger) {
     this->qr = qr;
 
-    Magick::Image image(Magick::Geometry(qr->width, qr->width),
-                        Magick::Color(Quantum(0), Quantum(0), Quantum(0),
-                                      Quantum(QuantumRange)));
+    // Background: use bg color with transparent alpha so the SMask
+    // reveals the PDF page behind non-module areas
+    Magick::Color bgColor(
+        bg.quantumRed(), bg.quantumGreen(), bg.quantumBlue(), 0);
+    Magick::Image image(Magick::Geometry(qr->width, qr->width), bgColor);
 
-    Magick::Color black("black");
-    image.fillColor(black);
-    image.strokeColor(black);
+    // Foreground: use fg color with opaque alpha for QR modules
+    Magick::Color fgColor(
+        fg.quantumRed(), fg.quantumGreen(), fg.quantumBlue(), QuantumRange);
+    image.fillColor(fgColor);
+    image.strokeColor(fgColor);
 
     int cellSize = 1;
 

--- a/src/imageProvider.h
+++ b/src/imageProvider.h
@@ -17,7 +17,9 @@ class ImageProvider : public QPDFObjectHandle::StreamDataProvider {
         ImageProvider(int width, int height, Logger& logger);
         ImageProvider(const std::string& filename, Logger& logger);
         ImageProvider(std::istream& stream, Logger& logger);
-        ImageProvider(const QRcode *qr, Logger& logger);
+        ImageProvider(const QRcode *qr, Logger& logger,
+                       const Magick::Color& fg = Magick::Color("black"),
+                       const Magick::Color& bg = Magick::Color("white"));
         virtual ~ImageProvider();
         virtual void provideStreamData(int objid, int generation,
                                        Pipeline *pipeline);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,12 @@ static int processPDF(
         logger << "QR version: " << qr->version << "\n";
         logger << "QR width: " << qr->width << "\n";
 
-        pdf_processor.addImage(new ImageProvider(qr, logger),
+        Magick::Color fgColor(
+            std::get<std::string>(cliOption.at("qr-fg-color")));
+        Magick::Color bgColor(
+            std::get<std::string>(cliOption.at("qr-bg-color")));
+
+        pdf_processor.addImage(new ImageProvider(qr, logger, fgColor, bgColor),
                                std::get<float>(cliOption.at("qr-scale")),
                                std::get<float>(cliOption.at("qr-top-margin")),
                                std::get<float>(cliOption.at("qr-side-margin")),

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -52,6 +52,8 @@ readCLIOptions(int argc, char *argv[], Logger &logger) {
         ("qr", value<std::string>(), "Add QR instead of image using the specified text")
         ("link", "QR value is a URL. Add clickable link")
         ("qr-ecc", value<std::string>()->default_value("M"), "QR error correction level: L (low), M (medium), Q (quartile), H (high)")
+        ("qr-fg-color", value<std::string>()->default_value("black"), "QR foreground color (name or hex, e.g. #000000)")
+        ("qr-bg-color", value<std::string>()->default_value("white"), "QR background color (name or hex, e.g. #FFFFFF)")
         ("qr-side", value<int>()->default_value(0), "Side of the document: 0 center (default), 1 left, 2 right")
         ("qr-scale", value<float>()->default_value(1),"Scale QR by a factor eg. 0.5")
         ("qr-top-margin", value<float>()->default_value(10),"Set a margin for the QR placement from the top of the page")
@@ -212,6 +214,9 @@ readCLIOptions(int argc, char *argv[], Logger &logger) {
                 "Invalid QR error correction level. Valid options: L, M, Q, H");
         }
         cliOption["qr-ecc"] = eccLevel;
+
+        cliOption["qr-fg-color"] = vm["qr-fg-color"].as<std::string>();
+        cliOption["qr-bg-color"] = vm["qr-bg-color"].as<std::string>();
     }
 
     float img_scale;

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -71,6 +71,28 @@ TEST(ImageProviderTest, CreateFromQR) {
     delete img;
 }
 
+TEST(ImageProviderTest, CreateFromQR_DefaultColors) {
+    QRcode *qr = QRcode_encodeString("colors", 0, QR_ECLEVEL_M,
+                                     QR_MODE_8, 1);
+    ASSERT_NE(qr, nullptr);
+    Magick::Color fg("black");
+    Magick::Color bg("white");
+    ImageProvider img(qr, logger, fg, bg);
+    EXPECT_EQ(img.getWidth(), qr->width);
+    QRcode_free(qr);
+}
+
+TEST(ImageProviderTest, CreateFromQR_CustomColors) {
+    QRcode *qr = QRcode_encodeString("red QR", 0, QR_ECLEVEL_M,
+                                     QR_MODE_8, 1);
+    ASSERT_NE(qr, nullptr);
+    Magick::Color fg("#FF0000");
+    Magick::Color bg("#0000FF");
+    ImageProvider img(qr, logger, fg, bg);
+    EXPECT_EQ(img.getWidth(), qr->width);
+    QRcode_free(qr);
+}
+
 TEST(ImageProviderTest, CreateFromQR_EccLevelL) {
     QRcode *qr = QRcode_encodeString("QR ECC L test", 0, QR_ECLEVEL_L,
                                      QR_MODE_8, 1);
@@ -509,6 +531,17 @@ TEST_F(CLITest, EmbedQRSuccess) {
     int ret = runBinary(args);
     EXPECT_EQ(ret, 0);
 
+    std::ifstream f(outPath);
+    EXPECT_TRUE(f.good());
+}
+
+TEST_F(CLITest, EmbedQRWithCustomColors) {
+    std::vector<std::string> args = {
+        "-i", inPath, "-o", outPath, "--qr", "colored-qr",
+        "--qr-fg-color", "red", "--qr-bg-color", "blue",
+    };
+    int ret = runBinary(args);
+    EXPECT_EQ(ret, 0);
     std::ifstream f(outPath);
     EXPECT_TRUE(f.good());
 }

--- a/tests/test_options.cpp
+++ b/tests/test_options.cpp
@@ -107,6 +107,9 @@ TEST(OptionsTest, ValidQRInvocation) {
     EXPECT_FLOAT_EQ(std::get<float>(opts["img-scale"]), 1.0f);
     // Default ECC level should be M (1)
     EXPECT_EQ(std::get<int>(opts["qr-ecc"]), 1);
+    // Default colors
+    EXPECT_EQ(std::get<std::string>(opts["qr-fg-color"]), "black");
+    EXPECT_EQ(std::get<std::string>(opts["qr-bg-color"]), "white");
 }
 
 TEST(OptionsTest, QrEccLevelL) {
@@ -152,6 +155,26 @@ TEST(OptionsInvalidTest, InvalidQrEccLevel) {
                            "X",              nullptr};
     EXPECT_THROW(readCLIOptions(argc, const_cast<char **>(argv), logger),
                  std::runtime_error);
+}
+
+TEST(OptionsTest, QrDefaultColors) {
+    int argc = 7;
+    const char *argv[] = {"qpdfImageEmbed", "-i",   "in.pdf", "-o",
+                           "out.pdf",        "--qr", "test",   nullptr};
+    auto opts = readCLIOptions(argc, const_cast<char **>(argv), logger);
+    EXPECT_EQ(std::get<std::string>(opts["qr-fg-color"]), "black");
+    EXPECT_EQ(std::get<std::string>(opts["qr-bg-color"]), "white");
+}
+
+TEST(OptionsTest, QrCustomColors) {
+    int argc = 11;
+    const char *argv[] = {"qpdfImageEmbed", "-i",           "in.pdf", "-o",
+                           "out.pdf",        "--qr",         "test",
+                           "--qr-fg-color",  "#FF0000",      "--qr-bg-color",
+                           "#00FF00",        nullptr};
+    auto opts = readCLIOptions(argc, const_cast<char **>(argv), logger);
+    EXPECT_EQ(std::get<std::string>(opts["qr-fg-color"]), "#FF0000");
+    EXPECT_EQ(std::get<std::string>(opts["qr-bg-color"]), "#00FF00");
 }
 
 TEST(OptionsInvalidTest, QrSideOutOfRange) {


### PR DESCRIPTION
Adds `--qr-fg-color` and `--qr-bg-color` CLI options to customize QR code foreground and background colors (default: black on white).

Also fixes a pre-existing bug where the QR image was entirely opaque black — background pixels now use transparent alpha so the PDF SMask correctly reveals the page behind non-module areas.

### Changes
- **src/imageProvider.h/.cpp**: QR constructor accepts `fg`/`bg` `Magick::Color` params (defaults: black/white); background uses alpha=0 (transparent), foreground uses alpha=QuantumRange (opaque)
- **src/options.cpp**: Add `--qr-fg-color` (default `black`) and `--qr-bg-color` (default `white`) options
- **src/main.cpp**: Parse colors from CLI options, pass to `ImageProvider`

### Tests (5 new, 82 total)
- **test_options**: Default colors, custom hex colors
- **test_integration**: ImageProvider with default/custom colors; CLI end-to-end with `--qr-fg-color red --qr-bg-color blue`

All 5 test executables pass (82 individual test cases).