### PR TITLE
feat: add --img-opacity option for transparency control

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,7 +69,9 @@ static int processPDF(
                                std::get<float>(cliOption.at("qr-scale")),
                                std::get<float>(cliOption.at("qr-top-margin")),
                                std::get<float>(cliOption.at("qr-side-margin")),
-                               std::get<std::string>(cliOption.at("link")));
+                               std::get<std::string>(cliOption.at("link")),
+                               nullptr,
+                               std::get<float>(cliOption.at("img-opacity")));
     }
 
     int img_side = 0;
@@ -88,18 +90,21 @@ static int processPDF(
             imgProvider = new ImageProvider(imageFile, logger);
         }
 
+        float opacity = std::get<float>(cliOption.at("img-opacity"));
         if (cliOption.contains("img-x")) {
             Point p(std::get<float>(cliOption.at("img-x")),
                     std::get<float>(cliOption.at("img-y")));
             pdf_processor.addImage(
                 imgProvider, std::get<float>(cliOption.at("img-scale")), 0, 0,
-                std::get<std::string>(cliOption.at("img-link-to")), &p);
+                std::get<std::string>(cliOption.at("img-link-to")), &p,
+                opacity);
         } else {
             pdf_processor.addImage(
                 imgProvider, std::get<float>(cliOption.at("img-scale")),
                 std::get<float>(cliOption.at("img-top-margin")),
                 std::get<float>(cliOption.at("img-side-margin")),
-                std::get<std::string>(cliOption.at("img-link-to")));
+                std::get<std::string>(cliOption.at("img-link-to")),
+                nullptr, opacity);
         }
     }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -34,6 +34,7 @@ readCLIOptions(int argc, char *argv[], Logger &logger) {
     imgOptions.add_options()
         ("stamp,s", value<std::string>(), "Image to embed (- for stdin)")
         ("img-scale", value<float>()->default_value(1),"Scale image by a factor eg. 0.5")
+        ("img-opacity", value<float>()->default_value(1),"Set image/QR opacity (0.0 = transparent, 1.0 = opaque)")
         ("img-link-to", value<std::string>()->default_value(""), "Image will be clickable linking to the url passed as argument");
 
     options_description imgRelPlacement("Image relative placement");
@@ -270,6 +271,13 @@ readCLIOptions(int argc, char *argv[], Logger &logger) {
     cliOption["qr-top-margin"] = vm["qr-top-margin"].as<float>();
 
     cliOption["qr-side-margin"] = vm["qr-side-margin"].as<float>();
+
+    float imgOpacity = vm["img-opacity"].as<float>();
+    if (imgOpacity < 0.0f || imgOpacity > 1.0f) {
+        throw std::runtime_error(
+            "Invalid value for option img-opacity. Valid range: 0.0 - 1.0");
+    }
+    cliOption["img-opacity"] = imgOpacity;
 
     cliOption["text"] = vm.count("add-text")
                             ? vm["add-text"].as<std::vector<std::string>>()

--- a/src/pdfProcessor.cpp
+++ b/src/pdfProcessor.cpp
@@ -1,8 +1,10 @@
 #include "pdfProcessor.h"
 #include "imageProvider.h"
 #include "logger.h"
+#include <qpdf/Buffer.hh>
 #include <qpdf/QPDFMatrix.hh>
 #include <qpdf/QPDFObjectHandle.hh>
+#include <memory>
 #include <random>
 #include <stdexcept>
 
@@ -125,7 +127,8 @@ std::string PDFProcessor::createNewImageName(const std::string& prefix) {
     return newName;
 }
 
-void PDFProcessor::createImageStream(ImageProvider *p, const std::string& name) {
+void PDFProcessor::createImageStream(ImageProvider *p, const std::string& name,
+                                     float opacity) {
     // Image object
     QPDFObjectHandle image = QPDFObjectHandle::newStream(&m_pdf);
     std::string imageString = std::string("<<"
@@ -158,26 +161,37 @@ void PDFProcessor::createImageStream(ImageProvider *p, const std::string& name) 
                                           std::to_string(p->getHeight()) + ">>";
     m_logger << "Transparency image string: " << transparencyImageString << "\n";
     transparency.replaceDict(QPDFObjectHandle::parse(transparencyImageString));
-    // Provide the stream data.
-    auto transparencyProvider = p->getAlpha();
-    m_logger << "Buffer size: " << transparencyProvider.get()->getSize() << "\n";
-    transparency.replaceStreamData(transparencyProvider,
-                                   QPDFObjectHandle::newNull(),
-                                   QPDFObjectHandle::newNull());
+
+    // Provide the stream data, scaling alpha by opacity if needed
+    auto alphaBuf = p->getAlpha();
+    m_logger << "Buffer size: " << alphaBuf->getSize() << "\n";
+    if (opacity < 1.0f) {
+        size_t size = alphaBuf->getSize();
+        unsigned char *raw = alphaBuf->getBuffer();
+        unsigned char *scaled = new unsigned char[size];
+        for (size_t i = 0; i < size; i++) {
+            scaled[i] = static_cast<unsigned char>(raw[i] * opacity);
+        }
+        auto scaledBuf = std::make_shared<Buffer>(scaled, size);
+        transparency.replaceStreamData(scaledBuf,
+                                       QPDFObjectHandle::newNull(),
+                                       QPDFObjectHandle::newNull());
+    } else {
+        transparency.replaceStreamData(alphaBuf,
+                                       QPDFObjectHandle::newNull(),
+                                       QPDFObjectHandle::newNull());
+    }
     m_xobject.replaceKey("/" + name + "tr", transparency);
-    std::string smaskString =
-        std::string(std::to_string(transparency.getObjectID()) + " " +
-                    std::to_string(transparency.getGeneration()) + " R");
     m_pdf.updateAllPagesCache();
     image.getDict().replaceKey("/SMask", transparency);
 }
 
 void PDFProcessor::addImage(ImageProvider *p, float scale, float topMargin,
                             float sideMargin, const std::string& link,
-                            Point *exactPosition) {
+                            Point *exactPosition, float opacity) {
 
     std::string imageName = createNewImageName("ImEPStampR");
-    createImageStream(p, imageName);
+    createImageStream(p, imageName, opacity);
 
     // To prevent our image appearing in unexpected places we save the initial
     // state at the beginning of the page and restore it at the end before

--- a/src/pdfProcessor.cpp
+++ b/src/pdfProcessor.cpp
@@ -168,11 +168,11 @@ void PDFProcessor::createImageStream(ImageProvider *p, const std::string& name,
     if (opacity < 1.0f) {
         size_t size = alphaBuf->getSize();
         unsigned char *raw = alphaBuf->getBuffer();
-        unsigned char *scaled = new unsigned char[size];
+        auto scaledBuf = std::make_shared<Buffer>(size);
+        unsigned char *scaled = scaledBuf->getBuffer();
         for (size_t i = 0; i < size; i++) {
             scaled[i] = static_cast<unsigned char>(raw[i] * opacity);
         }
-        auto scaledBuf = std::make_shared<Buffer>(scaled, size);
         transparency.replaceStreamData(scaledBuf,
                                        QPDFObjectHandle::newNull(),
                                        QPDFObjectHandle::newNull());

--- a/src/pdfProcessor.h
+++ b/src/pdfProcessor.h
@@ -21,7 +21,8 @@ class PDFProcessor {
 
         std::string rand_str(int length);
         std::string createNewImageName(const std::string& prefix);
-        void createImageStream(ImageProvider *p, const std::string& name);
+        void createImageStream(ImageProvider *p, const std::string& name,
+                               float opacity);
 
     public:
         PDFProcessor(Logger& logger);
@@ -32,7 +33,8 @@ class PDFProcessor {
         void setPosition(int side);
         void addImage(ImageProvider *p, float scale, float topMargin,
                       float sideMargin, const std::string& link = "",
-                      Point *exactPosition = nullptr);
+                      Point *exactPosition = nullptr,
+                      float opacity = 1.0f);
         void addExtraText(const std::string& text, float x, float y, float font_size,
                           const std::string& basefont, const std::string& style);
         void save(const std::string& filename);

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -197,6 +197,25 @@ TEST(PDFProcessorTest, EmbedQRAndVerify) {
     std::remove(outPath.c_str());
 }
 
+TEST(PDFProcessorTest, EmbedImageWithOpacity) {
+    std::string inPath = std::string(TEST_DATA_DIR) + "/blank.pdf";
+    std::string imgPath = std::string(TEST_DATA_DIR) + "/test_image.ppm";
+    std::string outPath = std::string(TEST_DATA_DIR) + "/_test_opacity.pdf";
+
+    PDFProcessor proc(logger);
+    ASSERT_TRUE(proc.open(inPath));
+
+    ImageProvider *img = new ImageProvider(imgPath, logger);
+    proc.addImage(img, 0.5f, 10.0f, 10.0f, "", nullptr, 0.5f);
+
+    proc.save(outPath);
+
+    QPDF verify;
+    EXPECT_NO_THROW(verify.processFile(outPath.c_str()));
+
+    std::remove(outPath.c_str());
+}
+
 TEST(PDFProcessorTest, EmbedImageWithLink) {
     std::string inPath = std::string(TEST_DATA_DIR) + "/blank.pdf";
     std::string imgPath = std::string(TEST_DATA_DIR) + "/test_image.ppm";
@@ -559,6 +578,28 @@ TEST_F(CLITest, EmbedQRWithEccL) {
 TEST_F(CLITest, EmbedQRWithEccH) {
     std::vector<std::string> args = {
         "-i", inPath, "-o", outPath, "--qr", "ecc-H-data", "--qr-ecc", "H",
+    };
+    int ret = runBinary(args);
+    EXPECT_EQ(ret, 0);
+    std::ifstream f(outPath);
+    EXPECT_TRUE(f.good());
+}
+
+TEST_F(CLITest, EmbedQRWithOpacity) {
+    std::vector<std::string> args = {
+        "-i", inPath, "-o", outPath, "--qr", "faded-qr",
+        "--img-opacity", "0.5",
+    };
+    int ret = runBinary(args);
+    EXPECT_EQ(ret, 0);
+    std::ifstream f(outPath);
+    EXPECT_TRUE(f.good());
+}
+
+TEST_F(CLITest, EmbedImageWithOpacity) {
+    std::vector<std::string> args = {
+        "-i", inPath, "-o", outPath, "--stamp", imgPath,
+        "--img-opacity", "0.3",
     };
     int ret = runBinary(args);
     EXPECT_EQ(ret, 0);

--- a/tests/test_options.cpp
+++ b/tests/test_options.cpp
@@ -110,6 +110,8 @@ TEST(OptionsTest, ValidQRInvocation) {
     // Default colors
     EXPECT_EQ(std::get<std::string>(opts["qr-fg-color"]), "black");
     EXPECT_EQ(std::get<std::string>(opts["qr-bg-color"]), "white");
+    // Default opacity
+    EXPECT_FLOAT_EQ(std::get<float>(opts["img-opacity"]), 1.0f);
 }
 
 TEST(OptionsTest, QrEccLevelL) {
@@ -175,6 +177,41 @@ TEST(OptionsTest, QrCustomColors) {
     auto opts = readCLIOptions(argc, const_cast<char **>(argv), logger);
     EXPECT_EQ(std::get<std::string>(opts["qr-fg-color"]), "#FF0000");
     EXPECT_EQ(std::get<std::string>(opts["qr-bg-color"]), "#00FF00");
+}
+
+TEST(OptionsTest, DefaultOpacity) {
+    int argc = 7;
+    const char *argv[] = {"qpdfImageEmbed", "-i",   "in.pdf", "-o",
+                           "out.pdf",        "--qr", "test",   nullptr};
+    auto opts = readCLIOptions(argc, const_cast<char **>(argv), logger);
+    EXPECT_FLOAT_EQ(std::get<float>(opts["img-opacity"]), 1.0f);
+}
+
+TEST(OptionsTest, CustomOpacity) {
+    int argc = 9;
+    const char *argv[] = {"qpdfImageEmbed", "-i",          "in.pdf", "-o",
+                           "out.pdf",        "--qr",        "test",
+                           "--img-opacity",  "0.5",         nullptr};
+    auto opts = readCLIOptions(argc, const_cast<char **>(argv), logger);
+    EXPECT_FLOAT_EQ(std::get<float>(opts["img-opacity"]), 0.5f);
+}
+
+TEST(OptionsInvalidTest, OpacityOutOfRange) {
+    int argc = 9;
+    const char *argv[] = {"qpdfImageEmbed", "-i",          "in.pdf", "-o",
+                           "out.pdf",        "--qr",        "test",
+                           "--img-opacity",  "1.5",         nullptr};
+    EXPECT_THROW(readCLIOptions(argc, const_cast<char **>(argv), logger),
+                 std::runtime_error);
+}
+
+TEST(OptionsInvalidTest, OpacityNegative) {
+    int argc = 9;
+    const char *argv[] = {"qpdfImageEmbed", "-i",          "in.pdf", "-o",
+                           "out.pdf",        "--qr",        "test",
+                           "--img-opacity",  "-0.1",        nullptr};
+    EXPECT_THROW(readCLIOptions(argc, const_cast<char **>(argv), logger),
+                 std::runtime_error);
 }
 
 TEST(OptionsInvalidTest, QrSideOutOfRange) {


### PR DESCRIPTION
Adds `--img-opacity` CLI option (0.0–1.0, default 1.0) to embed semi-transparent image stamps and QR codes.

The option scales alpha values in the SMask (transparency) stream when `opacity < 1.0`, affecting both file-based images with native alpha and QR codes.

### Changes
- **src/options.cpp**: Add `--img-opacity` option with range validation (0.0–1.0)
- **src/pdfProcessor.h**: Add `float opacity` param to `addImage()` (default 1.0) and `createImageStream()`
- **src/pdfProcessor.cpp**: Scale alpha buffer by opacity factor before creating SMask stream
- **src/main.cpp**: Pass `img-opacity` from CLI to `addImage()` for both QR and image paths

### Tests (7 new, 94+ total)
- **test_options**: default (1.0), custom (0.5), out-of-range (1.5), negative (-0.1)
- **test_integration**: PDFProcessor EmbedImageWithOpacity; CLI end-to-end with QR and image opacity